### PR TITLE
Fix validation logic for the chat history

### DIFF
--- a/packages/node/express/src/express/validators/chat/isValidConversationHistory.ts
+++ b/packages/node/express/src/express/validators/chat/isValidConversationHistory.ts
@@ -1,31 +1,28 @@
 export const isValidConversationHistory = (history: any) => {
     if (!Array.isArray(history)) {
         return {
-            success: false,
-            error: 'payload.conversationHistory is not an array',
-        };
-    }
-
-    if (history.some((item: any) => {
-        if (typeof item !== 'object' || item === null) {
-            return true;
-        }
-
-        if (
-            (item.role !== 'user' && item.role !== 'ai' && item.role !== 'system') ||
-            typeof item.message !== 'string'
-        ) {
-            return true;
-        }
-    })) {
-        return {
-            success: false,
-            error: 'payload.conversationHistory contains invalid items',
-        };
-    }
-
-    return {
-        success: true,
-        history,
+      success: false,
+      error: "payload.conversationHistory is not an array",
     };
+  }
+
+  if (history.some((item: any) => {
+    if (typeof item !== "object" || item === null) {
+      return true;
+    }
+
+    if (!["user", "ai", "system", "assistant"].includes(item.role) || typeof item.message !== "string") {
+      return true;
+    }
+    })) {
+    return {
+      success: false,
+      error: "payload.conversationHistory contains invalid items"
+    };
+  }
+
+  return {
+    success: true,
+    history
+  };
 };

--- a/packages/node/express/src/express/validators/chat/isValidConversationHistory.ts
+++ b/packages/node/express/src/express/validators/chat/isValidConversationHistory.ts
@@ -11,7 +11,7 @@ export const isValidConversationHistory = (history: any) => {
             return true;
         }
 
-        if (['user', 'ai', 'system', 'assistant'].includes(item.role) || typeof item.message !== 'string') {
+        if (!['user', 'ai', 'system', 'assistant'].includes(item.role) || typeof item.message !== 'string') {
             return true;
         }
     })) {

--- a/packages/node/express/src/express/validators/chat/isValidConversationHistory.ts
+++ b/packages/node/express/src/express/validators/chat/isValidConversationHistory.ts
@@ -1,28 +1,31 @@
 export const isValidConversationHistory = (history: any) => {
     if (!Array.isArray(history)) {
         return {
-      success: false,
-      error: "payload.conversationHistory is not an array",
-    };
-  }
-
-  if (history.some((item: any) => {
-    if (typeof item !== "object" || item === null) {
-      return true;
+            success: false,
+            error: 'payload.conversationHistory is not an array',
+        };
     }
 
-    if (!["user", "ai", "system", "assistant"].includes(item.role) || typeof item.message !== "string") {
-      return true;
-    }
+    if (history.some((item: any) => {
+        if (typeof item !== 'object' || item === null) {
+            return true;
+        }
+
+        if (
+            (item.role !== 'user' && item.role !== 'ai' && item.role !== 'system') ||
+            typeof item.message !== 'string'
+        ) {
+            return true;
+        }
     })) {
-    return {
-      success: false,
-      error: "payload.conversationHistory contains invalid items"
-    };
-  }
+        return {
+            success: false,
+            error: 'payload.conversationHistory contains invalid items',
+        };
+    }
 
-  return {
-    success: true,
-    history
-  };
+    return {
+        success: true,
+        history,
+    };
 };

--- a/packages/node/express/src/express/validators/chat/isValidConversationHistory.ts
+++ b/packages/node/express/src/express/validators/chat/isValidConversationHistory.ts
@@ -11,10 +11,7 @@ export const isValidConversationHistory = (history: any) => {
             return true;
         }
 
-        if (
-            (item.role !== 'user' && item.role !== 'ai' && item.role !== 'system') ||
-            typeof item.message !== 'string'
-        ) {
+        if (['user', 'ai', 'system', 'assistant'].includes(item.role) || typeof item.message !== 'string') {
             return true;
         }
     })) {

--- a/packages/node/server/src/serve/displayHelp.ts
+++ b/packages/node/server/src/serve/displayHelp.ts
@@ -8,8 +8,8 @@ export const displayHelp = () => {
     log('  @nlbridge/server [params]');
     log('');
     log('Required:');
-    log('  --api <openapi>     The AI backend to use\n' +
-        '                      Only OpenAPI is supported at the moment');
+    log('  --api <openai>     The AI backend to use\n' +
+        '                      Only OpenAI is supported at the moment');
     log('');
     log('Optional:');
     log('  --apiKey <key>      The API key to use for the AI backend\n' +

--- a/packages/node/server/src/serve/displayHelp.ts
+++ b/packages/node/server/src/serve/displayHelp.ts
@@ -12,7 +12,7 @@ export const displayHelp = () => {
         '                      Only OpenAPI is supported at the moment');
     log('');
     log('Optional:');
-    log('  --api-key <key>      The API key to use for the AI backend\n' +
+    log('  --apiKey <key>      The API key to use for the AI backend\n' +
         '                       Default: Read from environment variable (e.g. OPENAI_API_KEY)\n');
     log('  --port [port]        Port to use for HTTP server - Default: Random value between 8000 and 8999');
     log('  --cors <origin>      Enable CORS for the specified origin - Default: "*"');

--- a/pipeline/npm/server/README.md
+++ b/pipeline/npm/server/README.md
@@ -36,8 +36,8 @@ Usage:
   @nlbridge/server [params]
 
 Required:
-  --api <openapi>     The AI backend to use
-                      Only OpenAPI is supported at the moment
+  --api <openai>     The AI backend to use
+                      Only OpenAI is supported at the moment
 
 Optional:
   --apiKey <key>      The API key to use for the AI backend

--- a/pipeline/npm/server/README.md
+++ b/pipeline/npm/server/README.md
@@ -40,7 +40,7 @@ Required:
                       Only OpenAPI is supported at the moment
 
 Optional:
-  --api-key <key>      The API key to use for the AI backend
+  --apiKey <key>      The API key to use for the AI backend
                        Default: Read from environment variable (e.g. OPENAI_API_KEY)
 
   --port [port]        Port to use for HTTP server - Default: Random value between 8000 and 8999


### PR DESCRIPTION
This pull request includes a few changes to the validation logic, help display, and documentation for the server. The changes fix the validation of conversation history (#1 , #2) and update the help text and documentation to reflect the correct parameters.

Validation fixes:

* [`packages/node/express/src/express/validators/chat/isValidConversationHistory.ts`](diffhunk://#diff-192d6a4676f5613db1333e778e28944ca83198542692d1c36def72edb5ff89caL14-R14): Updated the `isValidConversationHistory` function to include 'assistant' as a valid role in conversation history.

Help text and documentation updates:

* [`packages/node/server/src/serve/displayHelp.ts`](diffhunk://#diff-2dbabd6e8aab15adeed7cec03174b1cd4e539d86c21eef896085b287073c6806L11-R15): Corrected the help text to use `--api <openai>` and `--apiKey <key>` instead of the previous `--api <openapi>` and `--api-key <key>`.
* [`pipeline/npm/server/README.md`](diffhunk://#diff-1d56b51dc04b5837287f645f7e8f032b45910819d3fd28d01ac1a2c4563548f7L39-R43): Updated the README to reflect the correct usage of `--api <openai>` and `--apiKey <key>` parameters.

Closes #1 
Closes #2