### PR TITLE
Update list of GPT models from OpenAI, including gpt-4o and removing some

### DIFF
--- a/packages/node/core/src/handlers/openai/types.ts
+++ b/packages/node/core/src/handlers/openai/types.ts
@@ -1,26 +1,14 @@
 export const supportedOpenAiChatModels = [
-    'gpt-4-0125-preview',
-    'gpt-4-turbo-preview',
-    'gpt-4-1106-preview',
-    'gpt-4-vision-preview',
-    'gpt-4',
-    'gpt-4-0314',
-    'gpt-4-0613',
-    'gpt-4-32k',
-    'gpt-4-32k-0314',
-    'gpt-4-32k-0613',
-    'gpt-3.5-turbo',
-    'gpt-3.5-turbo-16k',
-    'gpt-3.5-turbo-0301',
-    'gpt-3.5-turbo-0613',
-    'gpt-3.5-turbo-1106',
-    'gpt-3.5-turbo-0125',
-    'gpt-3.5-turbo-16k-0613',
+    "gpt-4",
+    "gpt-4-turbo",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-3.5-turbo",
 ];
 
 export type OpenAiChatModel = typeof supportedOpenAiChatModels[number];
 
-export const openAiDefaultChatModel: OpenAiChatModel = 'gpt-3.5-turbo';
+export const openAiDefaultChatModel: OpenAiChatModel = 'gpt-4o';
 
 export const asOpenAiChatModel = (value: any): OpenAiChatModel | undefined => {
     if (supportedOpenAiChatModels.includes(value)) {

--- a/packages/node/server/src/utils/createServer.ts
+++ b/packages/node/server/src/utils/createServer.ts
@@ -50,7 +50,7 @@ export const createServer = (config: ServerConfig) => {
 
     const middlewareConfig: MiddlewareConfig = {
         apiKey: config.apiKey,
-        chatModel: 'gpt-4'
+        chatModel: 'gpt-4o'
     }
 
     const nlbridge = defaultMiddleware(config.api, middlewareConfig);


### PR DESCRIPTION
This pull request updates the supported OpenAI chat models and modifies the default chat model used in server configuration. The most important changes include updating the list of supported models and changing the default chat model to `gpt-4o`.

Updates to supported OpenAI chat models:

* [`packages/node/core/src/handlers/openai/types.ts`](diffhunk://#diff-eab1329ff185372c917a126f4983c810e517645964a777fb27e9623b79357d2bL2-R11): Updated the list of supported OpenAI chat models to include `gpt-4`, `gpt-4-turbo`, `gpt-4o`, `gpt-4o-mini`, and `gpt-3.5-turbo`.
* [`packages/node/core/src/handlers/openai/types.ts`](diffhunk://#diff-eab1329ff185372c917a126f4983c810e517645964a777fb27e9623b79357d2bL2-R11): Changed the default OpenAI chat model from `gpt-3.5-turbo` to `gpt-4o`.

Server configuration changes:

* [`packages/node/server/src/utils/createServer.ts`](diffhunk://#diff-ba263a4c061bc96856fffc321ad9491588a23049ca9289fb4c015f575853d2ebL53-R53): Updated the `chatModel` in `middlewareConfig` from `gpt-4` to `gpt-4o`.